### PR TITLE
Check for namespace before attempting to fetch ETH balances

### DIFF
--- a/dapps/react-dapp-v2/src/helpers/api.ts
+++ b/dapps/react-dapp-v2/src/helpers/api.ts
@@ -105,6 +105,10 @@ export async function apiGetAccountBalance(
   address: string,
   chainId: string
 ): Promise<AssetData> {
+  const namespace = chainId.split(":")[0];  
+  if (namespace !== 'eip155') {
+    return { balance: "", symbol: "", name: "" };
+  }
   const ethChainId = chainId.split(":")[1];
   const rpc = rpcProvidersByChainId[Number(ethChainId)];
   if (!rpc) {


### PR DESCRIPTION
Check for `namespace` too, not only for chainId, while fetching ETH balances,  in case chains with different namespaces can have the same chainId as `eip155` chains